### PR TITLE
Fix missing l10n string for finish button

### DIFF
--- a/app/components/question-set/question/question.js
+++ b/app/components/question-set/question/question.js
@@ -39,7 +39,7 @@ export default class Question extends React.Component {
     const showPreviousButton = props.slideIndex !== 0;
 
     if (showFinishButton) {
-      this.instance.addButton('finish', 'Finish', () => {
+      this.instance.addButton('finish', this.l10n.finishButtonLabel, () => {
         this.props.parent.eventStore.trigger('showSolutionScreen');
       }, false);
 

--- a/app/entries/dist.js
+++ b/app/entries/dist.js
@@ -31,6 +31,7 @@ H5P.SpeakTheWordsSet = (function (Question) {
    * @property {string} solutionScreenResultsLabel
    * @property {string} showSolutionsButtonLabel
    * @property {string} retryButtonLabel
+   * @property {string} finishButtonLabel
    * @property {string} nextQuestionAriaLabel
    * @property {string} previousQuestionAriaLabel
    * @property {string} navigationBarTitle

--- a/language/.en.json
+++ b/language/.en.json
@@ -80,6 +80,10 @@
           "default": "Retry"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Next question accessibility label",
           "default": "Next question"
         },

--- a/language/af.json
+++ b/language/af.json
@@ -80,6 +80,10 @@
           "default": "Probeer weer"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Volgende vraag toeganklikheidsetiket",
           "default": "Volgende vraag"
         },

--- a/language/ar.json
+++ b/language/ar.json
@@ -80,6 +80,10 @@
           "default": "Retry"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "لافتة الوصول للسؤال التالي",
           "default": "Next question"
         },

--- a/language/bg.json
+++ b/language/bg.json
@@ -80,6 +80,10 @@
           "default": "Опитай пак"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Етикет за Следващ въпрос",
           "default": "Следващ въпрос"
         },

--- a/language/ca.json
+++ b/language/ca.json
@@ -80,6 +80,10 @@
           "default": "Torna-ho a provar"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Etiqueta d’accessibilitat per a la pregunta següent",
           "default": "Pregunta següent"
         },

--- a/language/cs.json
+++ b/language/cs.json
@@ -80,6 +80,10 @@
           "default": "Opakovat"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Popisek Další otázka",
           "default": "Další otázka"
         },

--- a/language/de.json
+++ b/language/de.json
@@ -80,6 +80,10 @@
           "default": "Wiederholen"
         },
         {
+          "label": "Beschriftung des \"Beenden\"-Buttons",
+          "default": "Beenden"
+        },
+        {
           "label": "Beschriftung des \"Weiter\"-Buttons für Vorlesewerkzeuge (Barrierefreiheit)",
           "default": "Nächste Frage"
         },

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -80,6 +80,10 @@
           "default": "Reintentar"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Etiqueta accesibilidad Pregunta siguiente",
           "default": "Pregunta siguiente"
         },

--- a/language/es.json
+++ b/language/es.json
@@ -80,6 +80,10 @@
           "default": "Intentar de nuevo"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Etiqueta de accesibilidad para Pregunta siguiente",
           "default": "Pregunta siguiente"
         },

--- a/language/et.json
+++ b/language/et.json
@@ -80,6 +80,10 @@
           "default": "Proovi uuesti"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Järgmine küsimus tekstilugeri silt",
           "default": "Järgmine küsimus"
         },

--- a/language/eu.json
+++ b/language/eu.json
@@ -80,6 +80,10 @@
           "default": "Saiatu berriro"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Hurrengo galdera erabilerraztasun etiketa",
           "default": "Hurrengo galdera"
         },

--- a/language/fa.json
+++ b/language/fa.json
@@ -80,6 +80,10 @@
           "default": "تلاش مجدد"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "برچسب دسترس‌پذیری سؤال بعدی",
           "default": "سؤال بعدی"
         },

--- a/language/fi.json
+++ b/language/fi.json
@@ -80,6 +80,10 @@
           "default": "Yritä uudelleen"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Ruudunlukijan seuraava kysymys teksti",
           "default": "Seuraava kysymys"
         },

--- a/language/fr.json
+++ b/language/fr.json
@@ -80,6 +80,10 @@
           "default": "Recommencer"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Accès à la question suivante",
           "default": "Question suivante"
         },

--- a/language/gl.json
+++ b/language/gl.json
@@ -1,6 +1,7 @@
 {
   "semantics": [
     {
+      "label": "Introdución",
       "fields": [
         {
           "label": "Amosar a introdución"
@@ -18,17 +19,16 @@
           "label": "Texto de introdución",
           "description": "Este título amosarase enriba do texto de introdución."
         }
-      ],
-      "label": "Introdución"
+      ]
     },
     {
       "label": "Preguntas",
-      "entity": "Pregunta",
       "widgets": [
         {
           "label": "Por defecto"
         }
       ],
+      "entity": "Pregunta",
       "field": {
         "label": "Pregunta"
       }
@@ -37,7 +37,13 @@
       "label": "Retroalimentación xeral",
       "fields": [
         {
+          "widgets": [
+            {
+              "label": "Por defecto"
+            }
+          ],
           "label": "Definir comentarios personalizados para calquera rango de puntuación",
+          "description": "Preme o botón \"Engadir rango\" para engadir tantos rangos como precises. Exemplo: 0-20% Mala puntuación, 21-91% Puntuación Media, 91-100% Puntuación estupenda!",
           "entity": "rango",
           "field": {
             "fields": [
@@ -50,13 +56,7 @@
                 "placeholder": "Escribe a túa retroalimentación"
               }
             ]
-          },
-          "widgets": [
-            {
-              "label": "Por defecto"
-            }
-          ],
-          "description": "Preme o botón \"Engadir rango\" para engadir tantos rangos como precises. Exemplo: 0-20% Mala puntuación, 21-91% Puntuación Media, 91-100% Puntuación estupenda!"
+          }
         }
       ]
     },
@@ -64,32 +64,36 @@
       "label": "Etiquetas e textos para o Conxunto de Di as Palabras",
       "fields": [
         {
-          "default": "Comeza o curso!",
-          "label": "Etiqueta do botón de introdución"
+          "label": "Etiqueta do botón de introdución",
+          "default": "Comeza o curso!"
         },
         {
-          "default": "Os teus resultados:",
-          "label": "Etiqueta de resultados da pantalla da solución"
+          "label": "Etiqueta de resultados da pantalla da solución",
+          "default": "Os teus resultados:"
         },
         {
-          "default": "Amosar a solución",
-          "label": "Etiqueta para botón amosar resposta"
+          "label": "Etiqueta para botón amosar resposta",
+          "default": "Amosar a solución"
         },
         {
-          "default": "Tentar de novo",
-          "label": "Etiqueta para o botón Tentar de novo"
+          "label": "Etiqueta para o botón Tentar de novo",
+          "default": "Tentar de novo"
         },
         {
-          "default": "Seguinte pregunta",
-          "label": "Etiqueta de accesibilidade para seguinte pregunta"
+          "label": "Finish button label",
+          "default": "Finish"
         },
         {
-          "default": "Pregunta anterior",
-          "label": "Etiqueta de accesibilidade para pregunta anterior"
+          "label": "Etiqueta de accesibilidade para seguinte pregunta",
+          "default": "Seguinte pregunta"
         },
         {
-          "description": "Títulos para preguntas na barra de navegación. Substituirase \":num\" polo número de diapositiva actual.",
+          "label": "Etiqueta de accesibilidade para pregunta anterior",
+          "default": "Pregunta anterior"
+        },
+        {
           "label": "Título da barra de navegación",
+          "description": "Títulos para preguntas na barra de navegación. Substituirase \":num\" polo número de diapositiva actual.",
           "default": "Diapositiva: núm"
         },
         {

--- a/language/it.json
+++ b/language/it.json
@@ -80,6 +80,10 @@
           "default": "Riprova"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Etichetta di accessibilità per la prossima domanda",
           "default": "Prossima domanda"
         },

--- a/language/km.json
+++ b/language/km.json
@@ -80,6 +80,10 @@
           "default": "សាកម្តងទៀត"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Next question accessibility label",
           "default": "សំណួរបន្ទាប់"
         },

--- a/language/ko.json
+++ b/language/ko.json
@@ -80,6 +80,10 @@
           "default": "재시도"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "다음 질문 있는 경우 레이블",
           "default": "다음 질문"
         },

--- a/language/lv.json
+++ b/language/lv.json
@@ -34,6 +34,7 @@
       }
     },
     {
+      "label": "Kopējā atgriezeniskā saite",
       "fields": [
         {
           "widgets": [
@@ -57,8 +58,7 @@
             ]
           }
         }
-      ],
-      "label": "Kopējā atgriezeniskā saite"
+      ]
     },
     {
       "label": "\"Izrunājiet vārdus kopa\" etiķetes un teksti",
@@ -80,6 +80,10 @@
           "default": "Atkārtot"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Nākamā jautājuma pieejamības etiķete",
           "default": "Nākamais jautājums"
         },
@@ -88,9 +92,9 @@
           "default": "Iepriekšējais jautājums"
         },
         {
+          "label": "Navigācijas joslas nosaukums",
           "description": "Jautājumu nosaukumi navigācijas joslā. \":num\" tiks aizstāts ar faktisko slaida numuru.",
-          "default": "Slaids :num",
-          "label": "Navigācijas joslas nosaukums"
+          "default": "Slaids :num"
         },
         {
           "label": "Atbildēto slaidu pieejamības etiķete",

--- a/language/nb.json
+++ b/language/nb.json
@@ -80,6 +80,10 @@
           "default": "Retry"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Next question accessibility label",
           "default": "Next question"
         },

--- a/language/nl.json
+++ b/language/nl.json
@@ -80,6 +80,10 @@
           "default": "Opnieuw"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Toegankelijkheidslabel voor \"Volgende vraag\"-knop",
           "default": "Volgende vraag"
         },

--- a/language/nn.json
+++ b/language/nn.json
@@ -80,6 +80,10 @@
           "default": "Prøv igjen"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Next question accessibility label",
           "default": "Neste spørsmål"
         },

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -80,6 +80,10 @@
           "default": "Tentar Novamente"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Rótulo de acessibilidade da próxima questão",
           "default": "Próxima questão"
         },

--- a/language/ru.json
+++ b/language/ru.json
@@ -80,6 +80,10 @@
           "default": "Повторить"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Ярлык доступности следующего вопроса",
           "default": "Следующий вопрос"
         },

--- a/language/sl.json
+++ b/language/sl.json
@@ -80,6 +80,10 @@
           "default": "Poskusi ponovno"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Besedilo za gumb \"Naslednje vprašanje\"",
           "default": "Naslednje vprašanje"
         },

--- a/language/sma.json
+++ b/language/sma.json
@@ -80,6 +80,10 @@
           "default": "Retry"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Next question accessibility label",
           "default": "Next question"
         },

--- a/language/sme.json
+++ b/language/sme.json
@@ -80,6 +80,10 @@
           "default": "Retry"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Next question accessibility label",
           "default": "Next question"
         },

--- a/language/smj.json
+++ b/language/smj.json
@@ -80,6 +80,10 @@
           "default": "Retry"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Next question accessibility label",
           "default": "Next question"
         },

--- a/language/sr.json
+++ b/language/sr.json
@@ -80,6 +80,10 @@
           "default": "Покушај поново"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Ознака за приступ следећем питању",
           "default": "Следеће питање"
         },

--- a/language/vi.json
+++ b/language/vi.json
@@ -80,6 +80,10 @@
           "default": "Thử lại"
         },
         {
+          "label": "Finish button label",
+          "default": "Finish"
+        },
+        {
           "label": "Nhãn truy cập câu hỏi tiếp theo",
           "default": "Câu hỏi tiếp theo"
         },

--- a/semantics.json
+++ b/semantics.json
@@ -196,6 +196,12 @@
         "default": "Retry"
       },
       {
+        "name": "finishButtonLabel",
+        "label": "Finish button label",
+        "type": "text",
+        "default": "Finish"
+      },
+      {
         "name": "nextQuestionAriaLabel",
         "label": "Next question accessibility label",
         "type": "text",


### PR DESCRIPTION
The label for the `Finish` button is currently hard-coded.

When merged in, will allow authors to translate the respective string.